### PR TITLE
Add onSave event to trigger the checkError

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -38,7 +38,8 @@
 						"title": "Check Errors",
 						"targets":	[
 							{ "uti": "com.netscape.javascript-source" }
-						]
+						],
+						"trigger": [{"event": "onSave"}]
 					},
 					{
 						"name": "cleanErrors",


### PR DESCRIPTION
This is just not to have to click on the toolbar to check the error but each time we save the file.